### PR TITLE
Minor formatting changes, and refactoring to tests to clarify intent

### DIFF
--- a/cordapp/src/integrationTest/kotlin/com/template/DriverBasedTest.kt
+++ b/cordapp/src/integrationTest/kotlin/com/template/DriverBasedTest.kt
@@ -45,9 +45,7 @@ class DriverBasedTest {
         }
     }
 
-    // *********************
-    // * Utility functions *
-    // *********************
+    // region Utility functions
 
     // Runs a test inside the Driver DSL, which provides useful functions for starting nodes, etc.
     private fun withDriver(test: DriverDSL.() -> Unit) = driver(
@@ -69,4 +67,6 @@ class DriverBasedTest {
     private fun DriverDSL.startWebServers(vararg identities: TestIdentity) = startNodes(*identities)
         .map { startWebserver(it) }
         .waitForAll()
+
+    // endregion
 }

--- a/cordapp/src/main/kotlin/com/template/App.kt
+++ b/cordapp/src/main/kotlin/com/template/App.kt
@@ -21,9 +21,8 @@ class TemplateApi(val rpcOps: CordaRPCOps) {
     @GET
     @Path("templateGetEndpoint")
     @Produces(MediaType.APPLICATION_JSON)
-    fun templateGetEndpoint(): Response {
-        return Response.ok("Template GET endpoint.").build()
-    }
+    fun templateGetEndpoint(): Response =
+        Response.ok("Template GET endpoint.").build()
 }
 
 // *********
@@ -33,30 +32,26 @@ class TemplateApi(val rpcOps: CordaRPCOps) {
 @StartableByRPC
 class Initiator : FlowLogic<Unit>() {
     @Suspendable
-    override fun call() {
-        return Unit
-    }
+    override fun call() = Unit
 }
 
 @InitiatedBy(Initiator::class)
 class Responder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
-    override fun call() {
-        return Unit
-    }
+    override fun call() = Unit
 }
 
 // ***********
 // * Plugins *
 // ***********
 class TemplateWebPlugin : WebServerPluginRegistry {
-    // A list of classes that expose web JAX-RS REST APIs.
+    // A list of lambdas that create objects exposing web JAX-RS REST APIs.
     override val webApis: List<Function<CordaRPCOps, out Any>> = listOf(Function(::TemplateApi))
     //A list of directories in the resources directory that will be served by Jetty under /web.
     // This template's web frontend is accessible at /web/template.
     override val staticServeDirs: Map<String, String> = mapOf(
-            // This will serve the templateWeb directory in resources to /web/template
-            "template" to javaClass.classLoader.getResource("templateWeb").toExternalForm()
+        // This will serve the templateWeb directory in resources to /web/template
+        "template" to javaClass.classLoader.getResource("templateWeb").toExternalForm()
     )
 }
 

--- a/cordapp/src/main/kotlin/com/template/App.kt
+++ b/cordapp/src/main/kotlin/com/template/App.kt
@@ -21,8 +21,9 @@ class TemplateApi(val rpcOps: CordaRPCOps) {
     @GET
     @Path("templateGetEndpoint")
     @Produces(MediaType.APPLICATION_JSON)
-    fun templateGetEndpoint(): Response =
-        Response.ok("Template GET endpoint.").build()
+    fun templateGetEndpoint(): Response {
+        return Response.ok("Template GET endpoint.").build()
+    }
 }
 
 // *********
@@ -32,13 +33,17 @@ class TemplateApi(val rpcOps: CordaRPCOps) {
 @StartableByRPC
 class Initiator : FlowLogic<Unit>() {
     @Suspendable
-    override fun call() = Unit
+    override fun call() {
+        // Flow implementation goes here
+    }
 }
 
 @InitiatedBy(Initiator::class)
 class Responder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
-    override fun call() = Unit
+    override fun call() {
+        // Flow implementation goes here
+    }
 }
 
 // ***********

--- a/cordapp/src/main/kotlin/com/template/Client.kt
+++ b/cordapp/src/main/kotlin/com/template/Client.kt
@@ -10,9 +10,7 @@ import org.slf4j.Logger
  * Demonstration of how to use the CordaRPCClient to connect to a Corda Node and
  * stream the contents of the node's vault.
  */
-fun main(args: Array<String>) {
-    TemplateClient().main(args)
-}
+fun main(args: Array<String>) = TemplateClient().main(args)
 
 private class TemplateClient {
     companion object {

--- a/cordapp/src/test/kotlin/com/template/ContractTests.kt
+++ b/cordapp/src/test/kotlin/com/template/ContractTests.kt
@@ -4,7 +4,7 @@ import net.corda.testing.node.MockServices
 import org.junit.Test
 
 class ContractTests {
-    val ledgerServices = MockServices()
+    private val ledgerServices = MockServices()
 
     @Test
     fun `dummy test`() {

--- a/cordapp/src/test/kotlin/com/template/FlowTests.kt
+++ b/cordapp/src/test/kotlin/com/template/FlowTests.kt
@@ -1,31 +1,27 @@
 package com.template
 
 import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.StartedMockNode
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
 class FlowTests {
-    lateinit var network: MockNetwork
-    lateinit var a: StartedMockNode
-    lateinit var b: StartedMockNode
 
-    @Before
-    fun setup() {
-        network = MockNetwork(listOf("com.template"))
-        a = network.createNode()
-        b = network.createNode()
+    private val network = MockNetwork(listOf("com.template"))
+    private val a = network.createNode()
+    private val b = network.createNode()
+
+    init {
         listOf(a, b).forEach {
             it.registerInitiatedFlow(Responder::class.java)
         }
-        network.runNetwork()
     }
 
+    @Before
+    fun setup() = network.runNetwork()
+
     @After
-    fun tearDown() {
-        network.stopNodes()
-    }
+    fun tearDown() = network.stopNodes()
 
     @Test
     fun `dummy test`() {


### PR DESCRIPTION
A first PR, testing the waters. All of the changes here are cosmetic:

* Formatting changes to eliminate unnecessary block syntax, and fix indent length to 4 spaces.
* `val`s in test classes declared `private`. This may be overkill; the only purpose is to remove an IDE underline.
* Changes to `DriverBasedTest` pulling out some utility functions in order to clarify intention in the test body. It may be that these functions are distracting and that it would be better to keep their functionality inline - my preference is for expressing tests in something as close as possible to a DSL fitted to the cases to be tested, but in this case the goal of introducing beginners to the framework should obviously be considered paramount.
* Changes to `FlowTests` to eliminate `lateinit`, which is generally a bit of a smell. It may be that the `init` block is equally distasteful, and its contents should be moved inside the `setup` method.