### PR TITLE
ES-1992: Replace deprecated methods with recommended usage

### DIFF
--- a/workflows/src/main/kotlin/com/r3/developers/apples/workflows/RedeemApplesFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/apples/workflows/RedeemApplesFlow.kt
@@ -53,12 +53,12 @@ class RedeemApplesFlow : ClientStartableFlow {
         val buyer = memberLookup.lookup(buyerName)?.ledgerKeys?.first()
             ?: throw IllegalArgumentException("The buyer does not exist within the network")
 
-        val appleStampStateAndRef = utxoLedgerService.findUnconsumedStatesByType(AppleStamp::class.java)
-            .firstOrNull { stateAndRef -> stateAndRef.state.contractState.id == stampId }
+        val appleStampStateAndRef = utxoLedgerService.findUnconsumedStatesByExactType(AppleStamp::class.java, 100, Instant.now())
+            .results.firstOrNull { stateAndRef -> stateAndRef.state.contractState.id == stampId }
             ?: throw IllegalArgumentException("No apple stamp matching the stamp id $stampId")
 
-        val basketOfApplesStampStateAndRef = utxoLedgerService.findUnconsumedStatesByType(BasketOfApples::class.java)
-            .firstOrNull { basketStateAndRef -> basketStateAndRef.state.contractState.owner ==
+        val basketOfApplesStampStateAndRef = utxoLedgerService.findUnconsumedStatesByExactType(BasketOfApples::class.java, 100, Instant.now())
+            .results.firstOrNull { basketStateAndRef -> basketStateAndRef.state.contractState.owner ==
                     appleStampStateAndRef.state.contractState.issuer }
             ?: throw IllegalArgumentException("There are no eligible baskets of apples")
 

--- a/workflows/src/main/kotlin/com/r3/developers/cordapptemplate/utxoexample/workflows/GetChatFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/cordapptemplate/utxoexample/workflows/GetChatFlow.kt
@@ -10,6 +10,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import org.slf4j.LoggerFactory
+import java.time.Instant
 import java.util.*
 
 // A class to hold the deserialized arguments required to start the flow.
@@ -44,7 +45,7 @@ class GetChatFlow: ClientStartableFlow {
         // Note, this code brings all unconsumed states back, then filters them.
         // This is an inefficient way to perform this operation when there are a large number of chats.
         // Note, you will get this error if you input an id which has no corresponding ChatState (common error).
-        val states = ledgerService.findUnconsumedStatesByType(ChatState::class.java)
+        val states = ledgerService.findUnconsumedStatesByExactType(ChatState::class.java, 100, Instant.now()).results
         val state = states.singleOrNull {it.state.contractState.id == flowArgs.id}
             ?: throw CordaRuntimeException("Did not find an unique unconsumed ChatState with id ${flowArgs.id}")
 

--- a/workflows/src/main/kotlin/com/r3/developers/cordapptemplate/utxoexample/workflows/ListChatsFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/cordapptemplate/utxoexample/workflows/ListChatsFlow.kt
@@ -8,6 +8,7 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import org.slf4j.LoggerFactory
+import java.time.Instant
 import java.util.*
 
 
@@ -38,7 +39,7 @@ class ListChatsFlow : ClientStartableFlow {
         log.info("ListChatsFlow.call() called")
 
         // Queries the VNode's vault for unconsumed states and converts the result to a serializable DTO.
-        val states = ledgerService.findUnconsumedStatesByType(ChatState::class.java)
+        val states = ledgerService.findUnconsumedStatesByExactType(ChatState::class.java, 100, Instant.now()).results
         val results = states.map {
             ChatStateResults(
                 it.state.contractState.id,

--- a/workflows/src/main/kotlin/com/r3/developers/cordapptemplate/utxoexample/workflows/UpdateChatFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/cordapptemplate/utxoexample/workflows/UpdateChatFlow.kt
@@ -51,7 +51,7 @@ class UpdateChatFlow: ClientStartableFlow {
             // Note, this code brings all unconsumed states back, then filters them.
             // This is an inefficient way to perform this operation when there are a large number of chats.
             // Note, you will get this error if you input an id which has no corresponding ChatState (common error).
-            val stateAndRef = ledgerService.findUnconsumedStatesByType(ChatState::class.java).singleOrNull {
+            val stateAndRef = ledgerService.findUnconsumedStatesByExactType(ChatState::class.java, 100, Instant.now()).results.singleOrNull {
                 it.state.contractState.id == flowArgs.id
             } ?: throw CordaRuntimeException("Multiple or zero Chat states with id ${flowArgs.id} found.")
 


### PR DESCRIPTION
CorDapps code includes Corda API methods which were marked as terminally deprecated since 5.0 GA.
When building CPIs, it results in Deprecated warnings in the IDE console.
This change fixes the warnings by using the recommended methods.
Flows were manually tested following the "Running the Chat CorDapp" from Corda 5 documentation.