### PR TITLE
ENT-11793: Fix integration tests in JDK17 CorDapp

### DIFF
--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -33,8 +33,8 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testImplementation
-    integrationTestRuntime.extendsFrom testRuntimeOny
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOny
 }
 
 dependencies {
@@ -46,6 +46,7 @@ dependencies {
     cordaProvided "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaProvided  "$corda_release_group:corda:$corda_release_version"
     testImplementation "$corda_release_group:corda-node-driver:$corda_release_version"
+    testImplementation "$corda_core_release_group:corda-core-test-utils:$corda_core_release_version"
 
     // CorDapp dependencies.
     cordapp project(":contracts")


### PR DESCRIPTION
Integration tests were missed in previous PRs and were not verified.
For integration tests to work correctly the following changes were needed:
- Gradle syntax update: `integrationTestCompile` and `integrationTestRuntime` updated to `integrationTestImplementation` and `integrationTestRuntimeOnly` so the integration tests can use tests' dependencies, as per [Gradle docs](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal)
- add missing dependencies for integration tests
- add add-opens JVM args to integration tests where necessary